### PR TITLE
switched the way the page transitions to search.html, changed the style and structure of the pages to better match the example

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,39 +16,34 @@
 </head>
 
 <body>
-  <header>
-    <div class="jumbotron">
-      <h1>Bootstrap Tutorial</h1>
-      <p>Bootstrap is the most popular HTML, CSS...</p>
-    </div>
-  </header>
-
-
+  <main class="container" id="front-page">
+    <div class="row">
   <!--Container for homepage form-->
-  <container>
-    <form class="col-8 text-center mx-auto ">
-      <div class="form-group">
-        <label for="exampleFormControlInput1">Search</label>
-        <input type="text" class="form-control" id="exampleFormControlInput1" placeholder="Search item here" />
+      <div class="card col-12" id="main-card">
+        <div class="card-body">
+          <h1 class="card-title mb-4 text-center">Library of Congress Search Engine</h1>
+          <form class="text-center mx-auto ">
+            <div class="form-group">
+              <input type="text" class="form-control" id="exampleFormControlInput1" placeholder="Search!" />
+            </div>
+            <div class="form-group">
+              <select class="form-control" id="exampleFormControlSelect1">
+                <option>maps</option>
+                <option>audio</option>
+                <option>photos</option>
+                <option>manuscripts</option>
+                <option>film-and-videos</option>
+                <option>notated-music</option>
+                <option>websites</option>
+              </select>
+            </div>
+            <button type="submit" class="btn btn-primary btn-block">Search</button>
+          </form>
+        </div>
+
       </div>
-      <div class="form-group">
-        <label for="exampleFormControlSelect1">Example select</label>
-        <select class="form-control" id="exampleFormControlSelect1">
-          <option>maps</option>
-          <option>audio</option>
-          <option>photos</option>
-          <option>manuscripts</option>
-          <option>film-and-videos</option>
-          <option>notated-music</option>
-          <option>websites</option>
-        </select>
-      </div>
-      <button type="submit" class="btn btn-primary">Search</button>
-    </form>
-
-  </container>
-
-
+    </div>
+  </main>
 
 
 

--- a/script.js
+++ b/script.js
@@ -9,7 +9,7 @@ $(function clickMeButton() {
     //localStorage.setItem("searchQuery", searchQuery);
     //localStorage.setItem("searchFormat", searchFormat);
     // console.log(document.location);
-    document.location.replace("./search.html?q="+searchQuery+"&format=");
+    document.location.replace("./search.html?q="+searchQuery+"&format="+searchFormat);
   })
 });
 

--- a/script.js
+++ b/script.js
@@ -6,17 +6,26 @@ $(function clickMeButton() {
     event.preventDefault();
     var searchQuery = $("#exampleFormControlInput1").val();
     var searchFormat = $("#exampleFormControlSelect1").val();
-    localStorage.setItem("searchQuery", searchQuery);
-    localStorage.setItem("searchFormat", searchFormat);
+    //localStorage.setItem("searchQuery", searchQuery);
+    //localStorage.setItem("searchFormat", searchFormat);
     // console.log(document.location);
-    document.location.replace("./search.html");
+    document.location.replace("./search.html?q="+searchQuery+"&format=");
   })
 });
 
-function fetchData(searchQuery, searchFormat) {
-  var url = "https://www.loc.gov/" + searchFormat + "/?q=" + searchQuery + "&fo=json";
-  //var formattedUrl = url.replace(" ", "%20");
-  console.log(url);
+/* 
+ *  Holds all the logic for the submit button on click.
+ *  When the submit button is clicked, we want to:
+ *    1. Get the search query input text.
+ *    2. Get the format that the user selected.
+ *    3. Change the URL to /search-results.html?q={queryInput}&format={selectInput}
+ */
+function submitButtonOnClick(event) {
+  event.preventDefault();
+    
+  /* 1. Get the search query input text. */
+  var queryInputText = searchQueryInputElement.val();
+  console.log(queryInputText);
 
   fetch(url)
     .then(function (response) {
@@ -28,3 +37,31 @@ function fetchData(searchQuery, searchFormat) {
       console.log("data", data);
     });
 };
+var searchQueryInputElement = $("#exampleFormControlInput1");
+var searchButtonElement = $("button");
+var formatSelectElement = $("#exampleFormControlSelect1");
+
+/* 
+ *  Holds all the logic for the submit button on click.
+ *  When the submit button is clicked, we want to:
+ *    1. Get the search query input text.
+ *    2. Get the format that the user selected.
+ *    3. Change the URL to /search-results.html?q={queryInput}&format={selectInput}
+ 
+function submitButtonOnClick(event) {
+  event.preventDefault();
+    
+   1. Get the search query input text.
+  var queryInputText = searchQueryInputElement.val();
+  console.log(queryInputText);
+
+   2. Get the format that the user selected. 
+  selectedElement = formatSelectElement.children("option:selected");
+  selectedFormat = selectedElement.text()
+    
+   3. Change the URL to /search-results.html?q={queryInput}&format={selectInput} 
+  location.replace("./search.html?q="+queryInputText+"&format="+selectedFormat);
+}
+
+searchButtonElement.on("click", submitButtonOnClick);
+*/

--- a/search.html
+++ b/search.html
@@ -14,35 +14,27 @@
 </head>
 
 <body>
-  <header>
-    <div class="jumbotron">
-      <h1>Bootstrap Tutorial</h1>
-      <p>Bootstrap is the most popular HTML, CSS...</p>
-    </div>
-  </header>
-
-
   <!--Container for homepage form-->
   <main class="container-fluid">
     <div class="row">
-      <form class="col-3 text-left ">
+      <form class="col-3 text-left" id="search-column">
+        <h1 class="my-3">Library of Congress Search Engine</h1>
         <div class="form-group">
-          <label for="exampleFormControlInput1">Search</label>
           <input type="text" class="form-control" id="exampleFormControlInput1" placeholder="Search item here">
         </div>
         <div class="form-group">
-          <label for="exampleFormControlSelect1">Example select</label>
           <select class="form-control" id="exampleFormControlSelect1">
-            <option>maps</option>
-            <option>audio</option>
-            <option>photos</option>
-            <option>manuscripts</option>
-            <option>film-and-videos</option>
-            <option>notated-music</option>
-            <option>websites</option>
+            <option value="maps">maps</option>
+            <option value="audio">audio</option>
+            <option value="photos">photos</option>
+            <option value="manuscripts">manuscripts</option>
+            <option value="film-and-videos">film-and-videos</option>
+            <option value="notated-music">notated-music</option>
+            <option value="websites">websites</option>
           </select>
         </div>
-        <button type="submit" class="btn btn-primary">Search</button>
+        <button type="submit" class="btn btn-primary btn-block">Search</button>
+        <button type="submit" class="btn btn-danger d-block my-3 btn-block">← Go Back</button>
       </form>
 
       <section id="search-results" class="col-9">

--- a/search.js
+++ b/search.js
@@ -1,5 +1,6 @@
 var searchResultsElement = $("#search-results");
 var submitBtn = $(".btn-primary");
+
 /*
  *  Generates the search results that you see on the page when given a data blob representing the search results.
  */
@@ -8,7 +9,6 @@ function displaySearchResults(data) {
     searchResultsElement.empty();
     /* First, we want to create the header that displays "Showing results for " */
     var searchQuery = data.search.query;
-    console.log(searchQuery);
     var headerToAdd = $("<h2>");
     headerToAdd.attr("id", "search-results-header");
     headerToAdd.text("Showing results for " + searchQuery + ":");
@@ -58,7 +58,6 @@ function displaySearchResults(data) {
         } else {
             description = description + "No description for this entry";
         }
-        console.log(description);
 
         var descriptionToAdd = $("<p>");
         descriptionToAdd.addClass("card-text");
@@ -95,7 +94,7 @@ function goBackButtonOnClick(event) {
 
 function fetchData(searchQuery, searchFormat) {
     var url = "https://www.loc.gov/" + searchFormat + "/?q=" + searchQuery + "&fo=json";
-    console.log(url);
+    //console.log(url);
 
     fetch(url)
         .then(function (response) {
@@ -120,11 +119,30 @@ $(function startSearch() {
     })
 });
 
-//when redirected from another page, get item from local storage and execute search
+//when redirected from another page, get item from search params in the url and execute search
 $(function () {
-    var searchQuery = (localStorage.getItem("searchQuery"));
-    var searchFormat = (localStorage.getItem("searchFormat"));
-    console.log("topic: " + searchQuery);
-    console.log("type: " + searchFormat);
-    fetchData(searchQuery, searchFormat);
+    var queryString = location.search;
+    var urlParams = new URLSearchParams(queryString);
+    var searchFor = urlParams.get("q");
+    var format = urlParams.get("format");
+    
+    fetchData(searchFor, format);
 });
+
+/* 
+ *  I stole the idea for using a URLSearchParams Object from the following source on google:
+ *  https://www.sitepoint.com/get-url-parameters-with-javascript/
+ * 
+ *  When the search results page is loaded, we need to do the following:
+ *      1. We need to parse out the parameters, namely the search query and format we specified.
+ *      2. We need to call fetch to get the results with the parameters we parsed.
+ *
+ 1. We need to parse out the parameters, namely the search query and format we specified.
+var queryString = location.search;
+var urlParams = new URLSearchParams(queryString);
+var searchFor = urlParams.get("q");
+var format = urlParams.get("format");
+
+ 2. We need to call fetch to get the results with the parameters we parsed.
+fetchData(searchFor, format);
+*/

--- a/search.js
+++ b/search.js
@@ -1,5 +1,7 @@
 var searchResultsElement = $("#search-results");
 var submitBtn = $(".btn-primary");
+var goBackBtn = $(".btn-danger");
+var textInputElement = $("#exampleFormControlInput1");
 
 /*
  *  Generates the search results that you see on the page when given a data blob representing the search results.
@@ -10,6 +12,7 @@ function displaySearchResults(data) {
     /* First, we want to create the header that displays "Showing results for " */
     var searchQuery = data.search.query;
     var headerToAdd = $("<h2>");
+    headerToAdd.addClass("my-3");
     headerToAdd.attr("id", "search-results-header");
     headerToAdd.text("Showing results for " + searchQuery + ":");
     searchResultsElement.append(headerToAdd);
@@ -77,7 +80,7 @@ function displaySearchResults(data) {
 
         /* Now we create and add the button that links to whatever the result is.  */
         var linkToAdd = $("<a>");
-        linkToAdd.addClass("btn btn-primary mt-3");
+        linkToAdd.addClass("btn btn-dark mt-3");
         linkToAdd.attr("role", "button");
         linkToAdd.attr("href", resultURL);
         linkToAdd.attr("target", "_blank");
@@ -88,7 +91,9 @@ function displaySearchResults(data) {
     }
 }
 
+/* Logic for the go back button on click. */
 function goBackButtonOnClick(event) {
+    event.preventDefault();
     document.location.replace("./index.html");
 }
 
@@ -119,15 +124,22 @@ $(function startSearch() {
     })
 });
 
-//when redirected from another page, get item from search params in the url and execute search
+//when redirected from another page, get search params from the url and execute search
+//also set the text input element to the value of the search query
 $(function () {
     var queryString = location.search;
     var urlParams = new URLSearchParams(queryString);
     var searchFor = urlParams.get("q");
     var format = urlParams.get("format");
+
+    textInputElement.val(searchFor);
+    var selectFormatElement = document.getElementById("exampleFormControlSelect1");
+    selectFormatElement.value = format;
     
     fetchData(searchFor, format);
 });
+
+goBackBtn.on("click", goBackButtonOnClick);
 
 /* 
  *  I stole the idea for using a URLSearchParams Object from the following source on google:

--- a/style.css
+++ b/style.css
@@ -1,0 +1,42 @@
+:root {
+    --dark: darkslategrey;
+    --light: gainsboro;
+}
+
+body {
+    background-color: var(--dark);
+}
+
+#front-page {
+    height: 70vh;
+    width: 100%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.card {
+    background-color: var(--light);
+    color: var(--dark);
+}
+
+#search-column {
+    background-color: var(--light);
+}
+
+h1 {
+    font-weight: bold;
+
+    color: var(--dark);
+}
+
+h2 {
+    font-weight: bold;
+
+    color: var(--light);
+}
+
+h3 {
+    font-weight: bold;
+}


### PR DESCRIPTION
The following is a list of changes that I made:
- In the description of this project, the search result page URL is described as being ``/search-results.html?q=dogs&format=photos``. So, when we switch pages, instead of saving and loading stuff in local storage, I made the URL go to ``/search.html?q={dogs}&format={photos}``, and then when search.html loads, the first thing I do is parse the search query and format from the URL search parameters and send that to the fetch function. Sorry Mari.
- I switched the look of the site to better match the mockup shown, including colors.
- Added a go back button and attached logic to it.